### PR TITLE
Include parameter to encrypt database

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -12,7 +12,7 @@ public:
     static Database &get();
 
     // Initialize the database with a master key
-    bool initialize(const QString &masterKey);
+    bool initialize(const QString &masterKey, bool encrypted);
     bool isInitialized() const { return db != nullptr; }
     sqlite3 *getDatabase() const { return db; }
     void closeDatabase();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
     // NOTE: Debugging only. Refreshes the database on every run
     QFile::remove("/Users/fred/Library/Application Support/encrypted.db");
     auto &db = Database::get();
-    if (db.initialize("master key")) {
+    if (db.initialize("master key", false)) {
         std::cout << "Database initialized successfully." << std::endl;
     } else {
         std::cout << "Failed to initialize database." << std::endl;


### PR DESCRIPTION
For debugging purposes. Let's you use two databases, one unencrypted so that you can debug schemas
Clion has a sqlite plugin btw, if you symlink the db into the project folder it's very easy to view the db