### PR TITLE
Remove integration tests from main

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -12,7 +12,7 @@ public:
     static Database &get();
 
     // Initialize the database with a master key
-    bool initialize(const QString &masterKey, bool encrypted);
+    bool initialize(const QString &masterKey, bool encrypted = true);
     bool isInitialized() const { return db != nullptr; }
     sqlite3 *getDatabase() const { return db; }
     void closeDatabase();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,68 +23,23 @@
 #include "sessions/IdentitySession.h"
 #include "sql/queries.h"
 
-std::string generateRandomString(int length) {
-    // Define the characters you want to include in your random string.
-    // This example uses uppercase letters, lowercase letters, and digits.
-    const std::string characters =
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            "abcdefghijklmnopqrstuvwxyz"
-            "0123456789";
-
-    // Seed the random number generator.
-    // Using std::chrono::system_clock::now().time_since_epoch().count()
-    // provides a good, time-based seed.
-    std::mt19937 generator(static_cast<unsigned int>(
-        std::chrono::system_clock::now().time_since_epoch().count()
-    ));
-
-    // Create a distribution to pick random indices from the 'characters' string.
-    std::uniform_int_distribution<> distribution(0, characters.length() - 1);
-
-    std::string randomString;
-    randomString.reserve(length); // Pre-allocate memory for efficiency
-
-    for (int i = 0; i < length; ++i) {
-        randomString += characters[distribution(generator)];
-    }
-
-    return randomString;
-}
-
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
-    constexpr bool encrypted = false;
-    constexpr bool refresh_database = true;
+    constexpr bool refresh_database = false;
 
     auto &db = Database::get();
-    if (db.initialize("master key", encrypted)) {
+    if (db.initialize("master key")) {
         qDebug() << "Database initialized successfully.";
     } else {
         qDebug() << "Failed to initialize database.";
         return 1;
     }
 
-    auto master_password = std::make_unique<std::string>("correct horse battery stapler");
-
     // TODO: Debugging only
     if (refresh_database) drop_all_tables();
 
     init_schema();
 
-    register_user("sloggotesting11", std::make_unique<std::string>("1234"));
-    register_first_device();
-    login_user("sloggotesting11");
-    post_new_keybundles(
-        get_decrypted_keypair("device"),
-        generate_signed_prekey(),
-        generate_onetime_keys(100)
-    );
-
-    std::cout << "Press Enter to continue...";
-    std::cin.get();
-
-    auto [backlog, identity_id] = get_handshake_backlog();
-    IdentityManager::getInstance().update_or_create_identity_sessions(backlog, identity_id);
-    // WindowManager::instance().showLogin();
-    return app.exec();
+    WindowManager::instance().showLogin();
+    return QApplication::exec();
 }

--- a/src/ui/windows/login/login.cpp
+++ b/src/ui/windows/login/login.cpp
@@ -55,6 +55,9 @@ void Login::onLoginButtonClicked()
         StyledMessageBox::warning(this, "Error", "Passphrase cannot be longer than 64 characters");
         return;
     }
+    WindowManager::instance().showReceived();
+    hide();
+
 }
 
 void Login::onRegisterButtonClicked()


### PR DESCRIPTION
Sloggo if you're angrily reading this wondering where your code went, run IntegrationTests in the top right

Basically, main should now be used for manual e2e testing. Use IntegrationTest to quickly run the whole app flow